### PR TITLE
Added geodesic

### DIFF
--- a/example/lib/qiblah_maps.dart
+++ b/example/lib/qiblah_maps.dart
@@ -105,6 +105,7 @@ class _QiblahMapsState extends State<QiblahMaps> {
                     color: Theme.of(context).primaryColor,
                     width: 5,
                     zIndex: 4,
+                    geodesic: true,
                   )
                 ],
               ),


### PR DESCRIPTION
It used to draw direct shortest path from `current` location to `Mecca` location. Setting `geodesic` to true fixes the issue.
Definition of `Geodesic`
```
  /// Indicates whether the segments of the polyline should be drawn as geodesics, as opposed to straight lines
  /// on the Mercator projection.
  ///
  /// A geodesic is the shortest path between two points on the Earth's surface.
  /// The geodesic curve is constructed assuming the Earth is a sphere
```

Below is the example from Toronto/Canada

## Before
<img width="263" alt="Screenshot 2024-02-06 at 21 55 53" src="https://github.com/medyas/flutter_qiblah/assets/25245292/b8bcad2d-dcf8-495c-b894-ee2ef8b54ed2">

<img width="267" alt="Screenshot 2024-02-06 at 21 56 11" src="https://github.com/medyas/flutter_qiblah/assets/25245292/5bdadc24-f02f-476a-afb7-f52a3f1e4b90">


## After
<img width="267" alt="Screenshot 2024-02-06 at 21 54 38" src="https://github.com/medyas/flutter_qiblah/assets/25245292/17869a0e-f315-48a0-a8c9-28b6599708ac">
<img width="269" alt="Screenshot 2024-02-06 at 21 54 59" src="https://github.com/medyas/flutter_qiblah/assets/25245292/3101dd92-b1aa-45ec-8add-5cf8c8d3afc3">

